### PR TITLE
Add branch reference to cache entry functions

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,7 +6,7 @@ export const CACHE_FOLDER = ".vcpkg-cache";
 
 export const getCacheKeyPrefix = () => core.getInput("prefix") || "vcpkg/";
 
-export const getCurrentBranchRef = () => core.process.env.GITHUB_REF;
+export const getCurrentBranchRef = () => process.env.GITHUB_REF;
 
 export const resolvedCacheFolder = () => path.resolve(CACHE_FOLDER);
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,6 +6,8 @@ export const CACHE_FOLDER = ".vcpkg-cache";
 
 export const getCacheKeyPrefix = () => core.getInput("prefix") || "vcpkg/";
 
+export const getCurrentBranchRef = () => core.process.env.GITHUB_REF;
+
 export const resolvedCacheFolder = () => path.resolve(CACHE_FOLDER);
 
 export const getCacheKey = (filename, prefix) => {
@@ -23,7 +25,7 @@ export const getCachePath = (cacheKey, prefix) => {
   return path.join(CACHE_FOLDER, directory, filename).split(path.sep).join("/");
 };
 
-export const getExistingCacheEntries = async (token, prefix) => {
+export const getExistingCacheEntries = async (token, prefix, ref) => {
   const octokit = github.getOctokit(token);
 
   try {
@@ -31,6 +33,7 @@ export const getExistingCacheEntries = async (token, prefix) => {
       ...github.context.repo,
       key: prefix,
       per_page: 100,
+      ref,
     });
 
     return cacheEntries.map((c) => c.key);

--- a/src/restore.js
+++ b/src/restore.js
@@ -1,13 +1,20 @@
 import * as cache from "@actions/cache";
 import * as core from "@actions/core";
-import { getCacheKeyPrefix, getCachePath, getExistingCacheEntries, resolvedCacheFolder } from "./helpers.js";
+import {
+  getCacheKeyPrefix,
+  getCachePath,
+  getExistingCacheEntries,
+  resolvedCacheFolder,
+  getCurrentBranchRef,
+} from "./helpers.js";
 
 const token = core.getInput("token", { required: true });
+const ref = getCurrentBranchRef();
 const prefix = getCacheKeyPrefix();
 core.setOutput("path", resolvedCacheFolder());
 
 await core.group("Restoring vcpkg cache", async () => {
-  const actionsCaches = await getExistingCacheEntries(token, prefix);
+  const actionsCaches = await getExistingCacheEntries(token, prefix, ref);
 
   if (actionsCaches.length < 1) {
     core.info(`No cache entries found with prefix '${prefix}'`);

--- a/src/save.js
+++ b/src/save.js
@@ -8,14 +8,16 @@ import {
   getCachePath,
   getExistingCacheEntries,
   resolvedCacheFolder,
+  getCurrentBranchRef,
 } from "./helpers.js";
 
 const token = core.getInput("token", { required: true });
 const prefix = getCacheKeyPrefix();
+const ref = getCurrentBranchRef();
 const vcpkgArchivePath = resolvedCacheFolder();
 
 await core.group("Saving vcpkg cache", async () => {
-  const actionsCaches = new Set(await getExistingCacheEntries(token, prefix));
+  const actionsCaches = new Set(await getExistingCacheEntries(token, prefix, ref));
 
   try {
     const directories = await fs.readdir(vcpkgArchivePath, { withFileTypes: true });


### PR DESCRIPTION
This pull request introduces enhancements to the caching functionality of the `vcpkg` action by incorporating branch-specific cache handling. The changes ensure that cache operations (restore and save) are scoped to the current branch, improving cache accuracy and reducing potential conflicts.

### Enhancements to caching functionality:

* **Branch-specific cache handling**:
  - Added `getCurrentBranchRef` function in `src/helpers.js` to retrieve the current branch reference from the environment (`GITHUB_REF`) for use in cache operations.
  - Updated `getExistingCacheEntries` in `src/helpers.js` to accept an additional `ref` parameter, ensuring cache entries are fetched for the current branch.

* **Integration of branch-specific logic in restore and save operations**:
  - Modified `src/restore.js` to import the `getCurrentBranchRef` function, retrieve the current branch reference, and pass it to `getExistingCacheEntries` during the restore process.
  - Updated `src/save.js` to include the branch reference in the save operation by importing and utilizing `getCurrentBranchRef`.

Fixes #7 